### PR TITLE
Using widget key for PageView

### DIFF
--- a/lib/expandable_page_view.dart
+++ b/lib/expandable_page_view.dart
@@ -96,6 +96,7 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
   Widget _buildPageView() {
     if (isBuilder) {
       return PageView.builder(
+        key: widget.key,
         controller: _pageController,
         itemBuilder: _itemBuilder,
         itemCount: widget.itemCount,
@@ -110,6 +111,7 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
       );
     }
     return PageView(
+      key: widget.key,
       controller: _pageController,
       children: _sizeReportingChildren(),
       onPageChanged: widget.onPageChanged,


### PR DESCRIPTION
It would be useful to pass the `key` of the `ExpandablePageView` widget to the `PageView`, to be able to persist the state of the `PageView` itself using a `PageStorageKey`, for example.