### PR TITLE
Fix handling dynamically changing sizes

### DIFF
--- a/lib/size_reporting_widget.dart
+++ b/lib/size_reporting_widget.dart
@@ -15,15 +15,29 @@ class SizeReportingWidget extends StatefulWidget {
 }
 
 class _SizeReportingWidgetState extends State<SizeReportingWidget> {
+  final _widgetKey = GlobalKey();
   Size _oldSize;
 
   @override
   Widget build(BuildContext context) {
     WidgetsBinding.instance.addPostFrameCallback((_) => _notifySize());
-    return widget.child;
+    return NotificationListener<SizeChangedLayoutNotification>(
+      onNotification: (_) {
+        WidgetsBinding.instance.addPostFrameCallback((_) => _notifySize());
+        return true;
+      },
+      child: SizeChangedLayoutNotifier(
+        child: Container(
+          key: _widgetKey,
+          child: widget.child,
+        ),
+      ),
+    );
   }
 
   void _notifySize() {
+    final context = _widgetKey.currentContext;
+    if (context == null) return;
     final size = context?.size;
     if (_oldSize != size) {
       _oldSize = size;


### PR DESCRIPTION
Fixed version of `SizeReportingWidget` (credit: https://github.com/fluttercommunity/backdrop/blob/d4e10a5547a192052731992285bc9b2625f277b0/lib/scaffold.dart#L608). The previous one didn't work with dynamic widgets like `ExpandableListTile`. After expanding, the `PageView` height didn't resize.

An example that reproduces the problem:
```Dart
ExpandablePageView(
 children: [
   ExpansionTile(
     title: Text('Title'),
     children: [
       Text('Content'),
     ],
   ),
 ],
);
```