### PR TITLE
Prevent disposing of external PageController

### DIFF
--- a/lib/expandable_page_view.dart
+++ b/lib/expandable_page_view.dart
@@ -74,9 +74,7 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
     super.initState();
     _pageController = widget.controller ?? PageController();
     _pageController.addListener(_updatePage);
-    if (widget.controller == null) {
-      _shouldDisposePageController = true;
-    }
+    _shouldDisposePageController = widget.controller == null;
   }
 
   @override

--- a/lib/expandable_page_view.dart
+++ b/lib/expandable_page_view.dart
@@ -60,6 +60,7 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
   List<double> _heights;
   int _currentPage = 0;
   int _previousPage = 0;
+  bool _shouldDisposePageController = false;
 
   double get _currentHeight => _heights[_currentPage];
 
@@ -73,12 +74,17 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
     super.initState();
     _pageController = widget.controller ?? PageController();
     _pageController.addListener(_updatePage);
+    if (widget.controller == null) {
+      _shouldDisposePageController = true;
+    }
   }
 
   @override
   void dispose() {
     _pageController.removeListener(_updatePage);
-    _pageController.dispose();
+    if (_shouldDisposePageController) {
+      _pageController.dispose();
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
Disposing a `PageController` that was passed externally by the parent widget inside the child widget is not a good idea, because the parent widget creates a controller and manages its lifecycle, including making a dispose. Therefore, we can easily get this error: 
```
The following assertion was thrown while finalizing the widget tree:
A PageController was used after being disposed.

Once you have called dispose() on a PageController, it can no longer be used.
When the exception was thrown, this was the stack
#0      ChangeNotifier._debugAssertNotDisposed.<anonymous closure> 
package:flutter/…/foundation/change_notifier.dart:117
#1      ChangeNotifier._debugAssertNotDisposed 
package:flutter/…/foundation/change_notifier.dart:123
#2      ChangeNotifier.removeListener 
package:flutter/…/foundation/change_notifier.dart:178
#3      _AnimatedState.dispose 
package:flutter/…/widgets/transitions.dart:170
#4      StatefulElement.unmount 
package:flutter/…/widgets/framework.dart:4854
...
════════════════════════════════════════════════════════════════════════════════
```

The solution is to disallow a `PageController` disposing that was passed to the widget.