### PR TITLE
Fixed PageView initialization with non zero-index page

### DIFF
--- a/lib/expandable_page_view.dart
+++ b/lib/expandable_page_view.dart
@@ -94,6 +94,8 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
     _heights = _prepareHeights();
     _pageController = widget.controller ?? PageController();
     _pageController.addListener(_updatePage);
+    _currentPage = _pageController.initialPage;
+    _previousPage = _currentPage - 1 < 0 ? 0 : _currentPage - 1;
     _shouldDisposePageController = widget.controller == null;
   }
 


### PR DESCRIPTION
When you want to init PageView with any index besides 0, PageView display page with 0 index and with 0 height by default. 

To fix it we need to initialize _currentPage and _previousPage indexes.