### PR TITLE
Support useMaxSize param

### DIFF
--- a/lib/src/expandable_page_view.dart
+++ b/lib/src/expandable_page_view.dart
@@ -128,6 +128,14 @@ class ExpandablePageView extends StatefulWidget {
   /// This property defaults to true and must not be null.
   final bool padEnds;
 
+  /// Whether to maintain the size of the PageView according to the maximum size of the children.
+  ///
+  /// If this is set to true, the size of all children will be the same and has the value of the maximum size
+  /// of the children.
+  ///
+  /// This property defaults to false and must not be null.
+  final bool useMaxSize;
+
   ExpandablePageView({
     required List<Widget> children,
     this.controller,
@@ -147,6 +155,7 @@ class ExpandablePageView extends StatefulWidget {
     this.scrollBehavior,
     this.scrollDirection = Axis.horizontal,
     this.padEnds = true,
+    this.useMaxSize = false,
     Key? key,
   })  : assert(estimatedPageSize >= 0.0),
         children = children,
@@ -174,6 +183,7 @@ class ExpandablePageView extends StatefulWidget {
     this.scrollBehavior,
     this.scrollDirection = Axis.horizontal,
     this.padEnds = true,
+    this.useMaxSize = false,
     Key? key,
   })  : assert(estimatedPageSize >= 0.0),
         children = null,
@@ -223,6 +233,14 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
     }
     if (_shouldReinitializeHeights(oldWidget)) {
       _reinitializeSizes();
+    }
+
+    if (widget.useMaxSize) {
+      for (int i = 0; i < _sizes.length; i++) {
+        if (_sizes[_currentPage] > _sizes[i]) {
+          _sizes[i] = _sizes[_currentPage];
+        }
+      }
     }
   }
 
@@ -339,9 +357,23 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
   Widget _itemBuilder(BuildContext context, int index) {
     final item = widget.itemBuilder!(context, index);
     return OverflowPage(
-      onSizeChange: (size) => setState(
-        () => _sizes[index] = _isHorizontalScroll ? size.height : size.width,
-      ),
+      onSizeChange: (size) => setState(() {
+        if (widget.useMaxSize) {
+          for (int i = 0; i < _sizes.length; i++) {
+            if (_isHorizontalScroll) {
+              if (size.height > _sizes[i]) {
+                _sizes[i] = size.height;
+              }
+            } else {
+              if (size.width > _sizes[i]) {
+                _sizes[i] = size.width;
+              }
+            }
+          }
+        } else {
+          _sizes[index] = _isHorizontalScroll ? size.height : size.width;
+        }
+      }),
       child: item,
       alignment: widget.alignment,
       scrollDirection: widget.scrollDirection,
@@ -354,10 +386,23 @@ class _ExpandablePageViewState extends State<ExpandablePageView> {
         (index, child) => MapEntry(
           index,
           OverflowPage(
-            onSizeChange: (size) => setState(
-              () => _sizes[index] =
-                  _isHorizontalScroll ? size.height : size.width,
-            ),
+            onSizeChange: (size) => setState(() {
+              if (widget.useMaxSize) {
+                for (int i = 0; i < _sizes.length; i++) {
+                  if (_isHorizontalScroll) {
+                    if (size.height > _sizes[i]) {
+                      _sizes[i] = size.height;
+                    }
+                  } else {
+                    if (size.width > _sizes[i]) {
+                      _sizes[i] = size.width;
+                    }
+                  }
+                }
+              } else {
+                _sizes[index] = _isHorizontalScroll ? size.height : size.width;
+              }
+            }),
             child: child,
             alignment: widget.alignment,
             scrollDirection: widget.scrollDirection,


### PR DESCRIPTION
This PR allows the size of all children to be set as the same with the maximum size.
It helps in case we don't want the screen auto resized with other widgets when switching between pages.