### PR TITLE
fix: size calculation with viewportFraction < 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+* Fixed size calculation with `viewportFraction` - when `viewportFraction < 1.0`, height now correctly uses the maximum of all visible pages instead of only the current page ([#52](https://github.com/Limbou/expandable_page_view/issues/52))
+
 ## 1.1.0
 
 * Updated minimum supported Flutter version to 3.10.0 (Dart 3.0)


### PR DESCRIPTION
When viewportFraction < 1.0, multiple pages are visible simultaneously. Previously, height was based only on the current page, causing taller adjacent pages to be clipped.

Now calculates the maximum height of all visible pages based on viewportFraction value.

Fixes #52